### PR TITLE
Update example

### DIFF
--- a/layer0.config.js
+++ b/layer0.config.js
@@ -3,8 +3,8 @@ module.exports = {
   connector: "@layer0/starter",
   backends: {
     origin: {
-      domainOrIp: "layer0.co",
-      hostHeader: "layer0.co",
+      domainOrIp: "www.layer0.co",
+      hostHeader: "www.layer0.co",
     },
   },
 };

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -2,7 +2,6 @@ import install from '@layer0/prefetch/window/install'
 import installDevtools from '@layer0/devtools/install'
 
 document.addEventListener('DOMContentLoaded', function () {
-  
   installDevtools()
   install()
 })

--- a/src/route-handler.ts
+++ b/src/route-handler.ts
@@ -9,7 +9,7 @@ const handler: RouteHandler = async ({ cache, removeUpstreamResponseHeader, prox
 
   // convert absolute redirects to origin to relative
   // so that the user isn't transferred to the origin.
-  updateResponseHeader('location', /https:\/\/www.layer0.co\//gi, '/')
+  updateResponseHeader('location', /https:\/\/www\.layer0\.co\//gi, '/')
 }
 
 export default handler

--- a/src/route-handler.ts
+++ b/src/route-handler.ts
@@ -9,7 +9,7 @@ const handler: RouteHandler = async ({ cache, removeUpstreamResponseHeader, prox
 
   // convert absolute redirects to origin to relative
   // so that the user isn't transferred to the origin.
-  updateResponseHeader('location', /https?:\/\/example.com\//gi, '/');
+  updateResponseHeader('location', /https:\/\/www.layer0.co\//gi, '/')
 }
 
 export default handler

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -7,21 +7,21 @@ export default new Router()
   .use(starterRoutes)
 
   
-  // example routes for cacheable pages:
+  // example routes for cacheable pages
   .get('/', routeHandler)
-  .get('/collections/:path*', routeHandler)
-  .get('/products/:path*', routeHandler)
+  .get('/insights', routeHandler)
+  .get('/post/:path*', routeHandler)
   
-  // example route for cacheable assets:
-  .match('/images/:path*', ({ cache, proxy }) => {
-    cache(CACHE_ASSETS)
-    return proxy('origin')
-  })
+  // example route for cacheable assets
+  // .match('/images/:path*', ({ cache, proxy }) => {
+  //  cache(CACHE_ASSETS)
+  //  return proxy('origin')
+  // })
 
   // useful configs for generated outputs 
   .get('/service-worker.js', ({ cache, serviceWorker }) => {
-    cache(CACHE_ASSETS);
-    serviceWorker('dist/service-worker.js');
+    cache(CACHE_ASSETS)
+    serviceWorker('dist/service-worker.js')
   })
   .match('/main.js', ({ serveStatic, cache }) => {
     cache(CACHE_ASSETS)
@@ -34,11 +34,11 @@ export default new Router()
   })
 
   //////////////////////////////////////////////////////////
-  ////////// Static Prerendering examples       ////////////
+  ////////// Static Prerendering examples //////////////////
   //////////////////////////////////////////////////////////
   //
   // More details at:
-  // https://developer.moovweb.com/guides/static_prerendering
+  // https://docs.layer0.co/guides/static_prerendering
   // 
   // append this to the router call above before .fallback to enable
   // .prerender([

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -7,29 +7,23 @@ clientsClaim()
 
 new Prefetcher({
   plugins: [
-    // Uncomment to enable
-    // new DeepFetchPlugin([
-    //   {
-    //     selector: 'img',
-    //     maxMatches: 2,
-    //     attribute: 'data-src',
-    //     as: 'image',
-    //     callback: deepFetchImages,
-    //   },
-    // ]),
+    new DeepFetchPlugin([
+      {
+        selector: 'rounded-image',
+        maxMatches: 1,
+        attribute: 'src',
+        as: 'image',
+        callback: deepFetchImages
+      },
+    ]),
   ],
 })
 .route()
-// Specific domain caching based on a regex match
-// .cache(/^https:\/\/assets-global\.website-files\.com\/.*/) 
+.cache(/^https:\/\/assets-global\.website-files\.com\/.*/) // Specific domain caching based on a regex match
 
 // Callback function image selector
 // Customize as needed
 function deepFetchImages({ $el }: DeepFetchCallbackParam) {
   const urlTemplate = $el.attr('src')
-  const width = "900"
-  if (urlTemplate) {
-    const url = urlTemplate.replace(/\{width\}/,width)
-    prefetch(url, 'image')
-  }
+  prefetch(url, 'image')
 }


### PR DESCRIPTION
Considering that this is supposed to be an example proxying www.layer0.co, I updated it to include everything that would be required in the example. 
Right now the demo link layer0-docs-cdn-starter-template-default.layer0-limelight.link just redirects to www.layer0.co.